### PR TITLE
Fix FlowTests, incorrect Responder class name

### DIFF
--- a/cordapp/src/test/kotlin/com/template/FlowTests.kt
+++ b/cordapp/src/test/kotlin/com/template/FlowTests.kt
@@ -22,7 +22,7 @@ class FlowTests {
         a = nodes.partyNodes[0]
         b = nodes.partyNodes[1]
         nodes.partyNodes.forEach {
-            it.registerInitiatedFlow(Responder::class.java)
+            it.registerInitiatedFlow(IOUFlowResponder::class.java)
         }
         network.runNetwork()
     }


### PR DESCRIPTION
Failing Gradle test task due to incorrect Responder class name